### PR TITLE
Depend on colored2 instead of colored

### DIFF
--- a/cocoapods-update-if-you-dare.gemspec
+++ b/cocoapods-update-if-you-dare.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency "colored2"
+
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,4 +1,4 @@
-require 'colored'
+require 'colored2'
 
 module Pod
   class Command


### PR DESCRIPTION
The colored gem hasn't been updated in years. colored2 is a maintained
fork.

See https://github.com/CocoaPods/Xcodeproj/pull/463